### PR TITLE
refactor(messages): move shared attachments methods to AttachmentMixin

### DIFF
--- a/vkbottle/tools/mini_types/base/foreign_message.py
+++ b/vkbottle/tools/mini_types/base/foreign_message.py
@@ -3,15 +3,8 @@ from typing import TYPE_CHECKING, Any, Callable, Final, List, Optional, Union
 
 import pydantic
 from vkbottle_types.objects import (
-    AudioAudio,
-    DocsDoc,
-    MessagesAudioMessage,
     MessagesForeignMessage,
-    PhotosPhoto,
     UsersUserFull,
-    VideoVideoFull,
-    WallWallComment,
-    WallWallpostFull,
 )
 
 from vkbottle.modules import json, logger
@@ -20,11 +13,12 @@ if TYPE_CHECKING:
     from vkbottle.api import ABCAPI, API
 
 from .mention import Mention, replace_mention_validator
+from .mixins import AttachmentMixin
 
 PEER_ID_OFFSET: Final[int] = 2_000_000_000
 
 
-class BaseForeignMessageMin(MessagesForeignMessage, ABC):
+class BaseForeignMessageMin(MessagesForeignMessage, AttachmentMixin, ABC):
     unprepared_ctx_api: Optional[Any] = None
     replace_mention: Optional[bool] = None
     _mention: Optional[Mention] = None
@@ -67,69 +61,6 @@ class BaseForeignMessageMin(MessagesForeignMessage, ABC):
     @property
     def message_id(self) -> Optional[int]:
         return self.conversation_message_id or self.id
-
-    def get_attachment_strings(self) -> Optional[List[str]]:
-        if self.attachments is None:
-            return None
-
-        attachments = []
-        for attachment in self.attachments:
-            attachment_type = attachment.type.value
-            attachment_object = getattr(attachment, attachment_type)
-            if not hasattr(attachment_object, "id") or not hasattr(attachment_object, "owner_id"):
-                logger.debug("Got unsupported attachment type: {}", attachment_type)
-                continue
-
-            attachment_string = (
-                f"{attachment_type}{attachment_object.owner_id}_{attachment_object.id}"
-            )
-            if hasattr(attachment_object, "access_key"):
-                attachment_string += f"_{attachment_object.access_key}"
-
-            attachments.append(attachment_string)
-
-        return attachments
-
-    def get_wall_attachment(self) -> Optional[List["WallWallpostFull"]]:
-        if self.attachments is None:
-            return None
-        result = [attachment.wall for attachment in self.attachments if attachment.wall]
-        return result or None
-
-    def get_wall_reply_attachment(self) -> Optional[List["WallWallComment"]]:
-        if self.attachments is None:
-            return None
-        result = [
-            attachment.wall_reply for attachment in self.attachments if attachment.wall_reply
-        ]
-        return result or None
-
-    def get_photo_attachments(self) -> Optional[List["PhotosPhoto"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.photo for attachment in self.attachments if attachment.photo]
-
-    def get_video_attachments(self) -> Optional[List["VideoVideoFull"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.video for attachment in self.attachments if attachment.video]
-
-    def get_doc_attachments(self) -> Optional[List["DocsDoc"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.doc for attachment in self.attachments if attachment.doc]
-
-    def get_audio_attachments(self) -> Optional[List["AudioAudio"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.audio for attachment in self.attachments if attachment.audio]
-
-    def get_audio_message_attachments(self) -> Optional[List["MessagesAudioMessage"]]:
-        if self.attachments is None:
-            return None
-        return [
-            attachment.audio_message for attachment in self.attachments if attachment.audio_message
-        ]
 
     def get_message_id(self) -> Optional[int]:
         return self.id or self.conversation_message_id

--- a/vkbottle/tools/mini_types/base/message.py
+++ b/vkbottle/tools/mini_types/base/message.py
@@ -6,17 +6,10 @@ from typing import TYPE_CHECKING, Any, Callable, Final, List, Literal, Optional,
 
 import pydantic
 from vkbottle_types.objects import (
-    AudioAudio,
-    DocsDoc,
-    MessagesAudioMessage,
     MessagesConversationMember,
     MessagesForward,
     MessagesMessage,
-    PhotosPhoto,
     UsersUserFull,
-    VideoVideoFull,
-    WallWallComment,
-    WallWallpostFull,
 )
 
 from vkbottle.modules import json, logger
@@ -31,13 +24,14 @@ from vkbottle.tools.formatting import Format, Formatter
 
 from .foreign_message import BaseForeignMessageMin  # noqa: TC001
 from .mention import Mention, replace_mention_validator
+from .mixins import AttachmentMixin
 
 MessageText = Union[str, Formatter, Format]
 
 PEER_ID_OFFSET: Final[int] = 2_000_000_000
 
 
-class BaseMessageMin(MessagesMessage, ABC):
+class BaseMessageMin(MessagesMessage, AttachmentMixin, ABC):
     unprepared_ctx_api: Optional[Any] = None
     state_peer: Optional[StatePeer] = None
     reply_message: Optional[BaseForeignMessageMin] = None
@@ -111,69 +105,6 @@ class BaseMessageMin(MessagesMessage, ABC):
     @property
     def message_id(self) -> int:
         return self.id or self.conversation_message_id
-
-    def get_attachment_strings(self) -> Optional[List[str]]:
-        if self.attachments is None:
-            return None
-
-        attachments = []
-        for attachment in self.attachments:
-            attachment_type = attachment.type.value
-            attachment_object = getattr(attachment, attachment_type)
-            if not hasattr(attachment_object, "id") or not hasattr(attachment_object, "owner_id"):
-                logger.debug("Got unsupported attachment type: {}", attachment_type)
-                continue
-
-            attachment_string = (
-                f"{attachment_type}{attachment_object.owner_id}_{attachment_object.id}"
-            )
-            if hasattr(attachment_object, "access_key"):
-                attachment_string += f"_{attachment_object.access_key}"
-
-            attachments.append(attachment_string)
-
-        return attachments
-
-    def get_wall_attachment(self) -> Optional[List["WallWallpostFull"]]:
-        if self.attachments is None:
-            return None
-        result = [attachment.wall for attachment in self.attachments if attachment.wall]
-        return result or None
-
-    def get_wall_reply_attachment(self) -> Optional[List["WallWallComment"]]:
-        if self.attachments is None:
-            return None
-        result = [
-            attachment.wall_reply for attachment in self.attachments if attachment.wall_reply
-        ]
-        return result or None
-
-    def get_photo_attachments(self) -> Optional[List["PhotosPhoto"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.photo for attachment in self.attachments if attachment.photo]
-
-    def get_video_attachments(self) -> Optional[List["VideoVideoFull"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.video for attachment in self.attachments if attachment.video]
-
-    def get_doc_attachments(self) -> Optional[List["DocsDoc"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.doc for attachment in self.attachments if attachment.doc]
-
-    def get_audio_attachments(self) -> Optional[List["AudioAudio"]]:
-        if self.attachments is None:
-            return None
-        return [attachment.audio for attachment in self.attachments if attachment.audio]
-
-    def get_audio_message_attachments(self) -> Optional[List["MessagesAudioMessage"]]:
-        if self.attachments is None:
-            return None
-        return [
-            attachment.audio_message for attachment in self.attachments if attachment.audio_message
-        ]
 
     def get_message_id(self) -> Optional[int]:
         return self.id or self.conversation_message_id

--- a/vkbottle/tools/mini_types/base/mixins.py
+++ b/vkbottle/tools/mini_types/base/mixins.py
@@ -1,0 +1,79 @@
+from typing import Protocol, List, Optional
+from vkbottle_types.objects import (
+    AudioAudio,
+    DocsDoc,
+    MessagesAudioMessage,
+    PhotosPhoto,
+    VideoVideoFull,
+    WallWallComment,
+    WallWallpostFull,
+)
+from vkbottle.modules import logger
+
+class HasAttachments(Protocol):
+    attachments: Optional[List]''
+
+class AttachmentMixin:
+    def get_attachment_strings(self) -> Optional[List[str]]:
+        if self.attachments is None:
+            return None
+
+        attachments = []
+        for attachment in self.attachments:
+            attachment_type = attachment.type.value
+            attachment_object = getattr(attachment, attachment_type)
+            if not hasattr(attachment_object, "id") or not hasattr(attachment_object, "owner_id"):
+                logger.debug("Got unsupported attachment type: {}", attachment_type)
+                continue
+
+            attachment_string = (
+                f"{attachment_type}{attachment_object.owner_id}_{attachment_object.id}"
+            )
+            if hasattr(attachment_object, "access_key"):
+                attachment_string += f"_{attachment_object.access_key}"
+
+            attachments.append(attachment_string)
+
+        return attachments
+    
+    def get_wall_attachment(self) -> Optional[List["WallWallpostFull"]]:
+        if self.attachments is None:
+            return None
+        result = [attachment.wall for attachment in self.attachments if attachment.wall]
+        return result or None
+
+    def get_wall_reply_attachment(self) -> Optional[List["WallWallComment"]]:
+        if self.attachments is None:
+            return None
+        result = [
+            attachment.wall_reply for attachment in self.attachments if attachment.wall_reply
+        ]
+        return result or None
+
+    def get_photo_attachments(self) -> Optional[List["PhotosPhoto"]]:
+        if self.attachments is None:
+            return None
+        return [attachment.photo for attachment in self.attachments if attachment.photo]
+
+    def get_video_attachments(self) -> Optional[List["VideoVideoFull"]]:
+        if self.attachments is None:
+            return None
+        return [attachment.video for attachment in self.attachments if attachment.video]
+
+    def get_doc_attachments(self) -> Optional[List["DocsDoc"]]:
+        if self.attachments is None:
+            return None
+        return [attachment.doc for attachment in self.attachments if attachment.doc]
+
+    def get_audio_attachments(self) -> Optional[List["AudioAudio"]]:
+        if self.attachments is None:
+            return None
+        return [attachment.audio for attachment in self.attachments if attachment.audio]
+
+    def get_audio_message_attachments(self) -> Optional[List["MessagesAudioMessage"]]:
+        if self.attachments is None:
+            return None
+        return [
+            attachment.audio_message for attachment in self.attachments if attachment.audio_message
+        ]
+


### PR DESCRIPTION
Какую проблему решает ваш PR: ...
Extracts shared attachment-related methods from `BaseMessageMin` and `BaseForeignMessageMin` into a separate `AttachmentMixin`. This reduces code duplication and allows attachment handling methods to be used for any message type.

Связанные issue: # .

* [ ] Ваш код документирован.
* [ ] Для вашего кода есть тесты.
* [ ] Для вашего кода есть примеры использования в examples.
